### PR TITLE
Modifying format strings for Python 2.6

### DIFF
--- a/yamlsettings/__init__.py
+++ b/yamlsettings/__init__.py
@@ -23,10 +23,10 @@ def _locate_file(filepaths):
             break
     else:
         if len(filepaths) > 1:
-            raise IOError("unable to locate the settings file from:\n{}".
+            raise IOError("unable to locate the settings file from:\n{0}".
                           format('\n'.join(filepaths)))
         else:
-            raise IOError("unable to locate the settings file from: {}".
+            raise IOError("unable to locate the settings file from: {0}".
                           format(filepaths))
     return filepath
 
@@ -111,7 +111,7 @@ def update_from_env(yaml_dict, prefix=""):
           by CONFIG_DATABASES_LOCAL.
     '''
     def _set_env_var(path, node):
-        env_path = "{}{}{}".format(
+        env_path = "{0}{1}{2}".format(
             prefix.upper(),
             '_' if prefix else '',
             '_'.join([str(key).upper() for key in path])
@@ -119,7 +119,7 @@ def update_from_env(yaml_dict, prefix=""):
         env_val = os.environ.get(env_path, None)
         if env_val is not None:
             # convert the value to a YAML-defined type
-            env_dict = yamldict.load('val: {}'.format(env_val))
+            env_dict = yamldict.load('val: {0}'.format(env_val))
             return env_dict.val
         else:
             return None

--- a/yamlsettings/yamldict.py
+++ b/yamlsettings/yamldict.py
@@ -36,7 +36,7 @@ class YAMLDict(collections.OrderedDict):
         return dump(self, stream=None, default_flow_style=False)
 
     def __repr__(self):
-        return '<' + ', '.join(['{}: {}'.format(repr(k), repr(v))
+        return '<' + ', '.join(['{0}: {1}'.format(repr(k), repr(v))
                                for k, v in self.items()]) + '>'
 
     def traverse(self, callback):
@@ -57,7 +57,7 @@ class YAMLDict(collections.OrderedDict):
                                                  callback)
                 elif isinstance(node, list):
                     for i, v in enumerate(node):
-                        node[i] = _traverse_node(path + ['[{}]'.format(i)], v,
+                        node[i] = _traverse_node(path + ['[{0}]'.format(i)], v,
                                                  callback)
                 else:
                     pass
@@ -152,7 +152,7 @@ class YAMLDictLoader(yaml.Loader):
             raise yaml.constructor.ConstructorError(
                 None,
                 None,
-                'expected a mapping node, but found {}'.format(node.id),
+                'expected a mapping node, but found {0}'.format(node.id),
                 node.start_mark
             )
         mapping = YAMLDict()
@@ -164,7 +164,7 @@ class YAMLDictLoader(yaml.Loader):
                 raise yaml.constructor.ConstructorError(
                     'while constructing a mapping',
                     node.start_mark,
-                    'found unacceptable key ({})'.format(exc),
+                    'found unacceptable key ({0})'.format(exc),
                     key_node.start_mark
                 )
             value = self.construct_object(value_node, deep=deep)


### PR DESCRIPTION
Python 2.6 does not support a format string without a position, eg. '{}'.
Updated all of the format strings to use the format of '{0}'.
