### PR TITLE
Fix YamlSettingsExtension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,7 @@ setup.py
      author='Kyle Walker',
      author_email='KyleJamesWalker@gmail.com',
      description='Quick Example',
+     requirements=['yamlsettings'],
      py_modules=['yamlsettings_example'],
      entry_points={
          'yamlsettings10': [
@@ -172,10 +173,10 @@ yamlsettings_example.py
 
 .. code-block:: python
 
- import yamlsettings
+ from yamlsettings.extensions.base import YamlSettingsExtension
 
 
- class ZxcExtension(yamlsettings.YamlSettingsExtension):
+ class ZxcExtension(YamlSettingsExtension):
      """Quick Example Plugin
 
      Standard file opener, but will merge in values passed to kwargs

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requirements.update(all=sorted(set().union(*requirements.values())))
 
 setup(
     name='yamlsettings',
-    version='1.0.1',
+    version='1.0.2',
     description='Yaml Settings Configuration Module',
     long_description=readme,
     author='Kyle James Walker',

--- a/tests/extensions/test_registry.py
+++ b/tests/extensions/test_registry.py
@@ -1,12 +1,12 @@
 """Test registry"""
 import pytest
 import yamlsettings
+from yamlsettings.extensions.base import YamlSettingsExtension
 from yamlsettings.extensions.registry import ExtensionRegistry
-
 from mock import Mock
 
 
-class MockExtension(yamlsettings.YamlSettingsExtension):
+class MockExtension(YamlSettingsExtension):
     protocols = ['mock']
 
     @classmethod
@@ -16,7 +16,7 @@ class MockExtension(yamlsettings.YamlSettingsExtension):
         return load_method("mock: test")
 
 
-class MockExtension2(yamlsettings.YamlSettingsExtension):
+class MockExtension2(YamlSettingsExtension):
     protocols = ['mock2']
 
     @classmethod

--- a/yamlsettings/__init__.py
+++ b/yamlsettings/__init__.py
@@ -15,7 +15,6 @@ from yamlsettings.helpers import (
 from yamlsettings.extensions import (
     registry,
     RegistryError,
-    YamlSettingsExtension,
 )
 
 load = registry.load
@@ -32,5 +31,4 @@ __all__ = [
     'YamlSettings',
     'registry',
     'RegistryError',
-    'YamlSettingsExtension',
 ]

--- a/yamlsettings/extensions/__init__.py
+++ b/yamlsettings/extensions/__init__.py
@@ -6,7 +6,6 @@ Proposed types:
       each://defaults.yaml|settings.yaml|more.yaml
 
 """
-from yamlsettings.extensions.base import YamlSettingsExtension
 from yamlsettings.extensions.local import LocalExtension
 from yamlsettings.extensions.package import PackageExtension
 from yamlsettings.extensions.registry import ExtensionRegistry, RegistryError
@@ -16,4 +15,4 @@ registry = ExtensionRegistry([
     PackageExtension,
 ])
 
-__all__ = ['registry', 'YamlSettingsExtension', 'RegistryError']
+__all__ = ['registry', 'RegistryError']

--- a/yamlsettings/extensions/local.py
+++ b/yamlsettings/extensions/local.py
@@ -1,5 +1,5 @@
 """Load a yaml from from the local filesystem"""
-from yamlsettings.extensions import YamlSettingsExtension
+from yamlsettings.extensions.base import YamlSettingsExtension
 
 
 class LocalExtension(YamlSettingsExtension):

--- a/yamlsettings/extensions/package.py
+++ b/yamlsettings/extensions/package.py
@@ -2,7 +2,7 @@
 import pkgutil
 
 import yamlsettings
-from yamlsettings.extensions import YamlSettingsExtension
+from yamlsettings.extensions.base import YamlSettingsExtension
 
 
 class PackageExtension(YamlSettingsExtension):

--- a/yamlsettings/extensions/registry.py
+++ b/yamlsettings/extensions/registry.py
@@ -26,7 +26,7 @@ class ExtensionRegistry(object):
         """A registry that stores extensions to open and parse Target URIs
 
         :param extensions: A list of extensions.
-        :type extensions: yamlsettings.extensions.YamlSettingsExtension
+        :type extensions: yamlsettings.extensions.base.YamlSettingsExtension
 
         """
         self.registry = {}
@@ -61,7 +61,7 @@ class ExtensionRegistry(object):
         """Adds an extension to the registry
 
         :param extension: Extension object
-        :type extension: yamlsettings.extensions.YamlSettingsExtension
+        :type extension: yamlsettings.extensions.base.YamlSettingsExtension
 
         """
         index = len(self.extensions)


### PR DESCRIPTION
When YamlSettingsExtension was defined via
yamlsettings.YamlSettingsExtension, a plugin would create a circular
import, and python would fail.  This updates the doc to use,
yamlsettings.extensions.base.YamlSettingsExtension and removes the top
level reference.