### PR TITLE
Fix load_all for packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 language: python
 python:
 - '2.7'
-- '3.4'
 - '3.5'
 - '3.6'
+- '3.7'
+- '3.8'
 install: pip install tox-travis codecov
 script: tox
 deploy:

--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,17 @@ yamlsettings_example.py
                      load_method, **kwargs):
          full_path = (hostname or '') + path
          obj = load_method(open(full_path, **query))
-         obj.update(kwargs)
+
+         # Load all returns a generator list of configurations
+         many = isinstance(obj, types.GeneratorType)
+         obj = list(obj) if many else obj
+
+         if many:
+             for x in obj:
+                 x.update(kwargs)
+         else:
+             obj.update(kwargs)
+
          return obj
 
 usage

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements.update(all=sorted(set().union(*requirements.values())))
 
 setup(
     name='yamlsettings',
-    version='2.0.1',
+    version='2.0.2',
     description='Yaml Settings Configuration Module',
     long_description=readme,
     author='Kyle James Walker',

--- a/tests/extensions/test_package.py
+++ b/tests/extensions/test_package.py
@@ -2,7 +2,9 @@
 
 """
 import pytest
+import yaml
 import yamlsettings
+
 from yamlsettings.extensions.package import PackageExtension
 from yamlsettings.extensions.registry import ExtensionRegistry
 
@@ -48,6 +50,21 @@ def test_package_config(package_data, data_input):
     cfg = yamlsettings.load('package://example')
     assert cfg.mocked.startswith("package")
     assert package_data.call_count == 1
+
+
+def test_load_all(package_data):
+    """Verify load_all works"""
+    package_data.return_value = b'---\nfoo: first\n---\nfoo: second'
+
+    # Verify failure with single load
+    with pytest.raises(yaml.composer.ComposerError):
+        yamlsettings.load('package://example')
+
+    # Load all segments
+    cfg = yamlsettings.load_all('package://example')
+    assert cfg[0].foo == 'first'
+    assert cfg[1].foo == 'second'
+    assert len(cfg) == 2
 
 
 def test_no_package_data(package_data):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ max-line-length = 80
 max-complexity = 20
 
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py27, py35, py36, py37, py38
 
 [testenv]
 deps =

--- a/yamlsettings/extensions/package.py
+++ b/yamlsettings/extensions/package.py
@@ -1,5 +1,6 @@
 """Load a yaml resource from a python package."""
 import pkgutil
+import types
 
 import yamlsettings
 from yamlsettings.extensions.base import YamlSettingsExtension
@@ -49,7 +50,14 @@ class PackageExtension(YamlSettingsExtension):
                 raise IOError("package - {}:{}".format(package_path, resource))
 
             yaml_contents = load_method(pkg_data)
-            if env:
+            # Load all returns a generator list of configurations
+            many = isinstance(yaml_contents, types.GeneratorType)
+            yaml_contents = list(yaml_contents) if many else yaml_contents
+
+            if env and many:
+                for contents in yaml_contents:
+                    yamlsettings.update_from_env(contents, prefix)
+            elif env:
                 yamlsettings.update_from_env(yaml_contents, prefix)
 
             if persist:


### PR DESCRIPTION
yaml.load_all returns a generator, so the package extension failed loading and caching settings with multiple documents.